### PR TITLE
update for holonix 0.0.81

### DIFF
--- a/src/dna-setup/scripts/generate-dna-zomes.js
+++ b/src/dna-setup/scripts/generate-dna-zomes.js
@@ -33,7 +33,7 @@ const updateZomeCargoToml = (zomeDir) => {
   const cargoToml = toml.parse(fs.readFileSync(`${zomeCodeDir}/Cargo.toml`, 'utf8'))    
   const newCargoTomlDependencies = {
     ...cargoToml.dependencies,
-    'holochain_anchors': { git: "https://github.com/holochain/holochain-anchors",  branch: "master" }
+    'holochain_anchors': { git: "https://github.com/holochain/holochain-anchors",  tag: "v0.2.7" }
   }
   Object.assign(cargoToml.dependencies, newCargoTomlDependencies)
   const tomlConvertionCargo = json2toml(cargoToml)


### PR DESCRIPTION
bumped `holochain-anchors` dep; that's about it. It changes the way the dep is specified too -- targets a release tag, which targets a specific version of `hdk`, rather than targeting the `master` branch.